### PR TITLE
1:1 with openpi policies

### DIFF
--- a/vla-scripts/openpi_server.py
+++ b/vla-scripts/openpi_server.py
@@ -60,6 +60,8 @@ def run_policy(vla, obs):
         ),
         max_tokens=128,
     )
+    action = {"actions" : action}
+
     return action
 
 


### PR DESCRIPTION
return actions in a dict {"actions": NPARRAY} as with openpi droid policies, to match interface